### PR TITLE
Edits to PR #584: Intersphinx and pytest skip

### DIFF
--- a/docs/source/guide/guide-executors.rst
+++ b/docs/source/guide/guide-executors.rst
@@ -290,13 +290,13 @@ real quantum hardware.
 
 Qiskit Executors
 ======================================
-See  :py:mod:`mitiq.mitiq_qiskit.qiskit_utils`.
+See  :py:mod:`~mitiq.mitiq_qiskit.qiskit_utils`.
 
 This section includes noisy and noiseless simulator executor examples you can use on Qiskit circuits.
 
 Qiskit: Wavefunction Simulation
 ---------------------------------
-See :py:func:`mitiq.mitiq_qiskit.qiskit_utils.execute`.
+See :py:func:`~mitiq.mitiq_qiskit.qiskit_utils.execute` in :py:mod:`~mitiq.mitiq_qiskit.qiskit_utils`.
 
 This executor can be used for noiseless simulation. Note that this executor
 can be :ref:`wrapped using partial function application <partial-note>`
@@ -304,7 +304,7 @@ to be used in Mitiq.
 
 Qiskit: Wavefunction Simulation with Sampling
 -----------------------------------------------
-See :py:func:`mitiq.mitiq_qiskit.qiskit_utils.execute_with_shots`.
+See :py:func:`~mitiq.mitiq_qiskit.qiskit_utils.execute_with_shots` in :py:mod:`~mitiq.mitiq_qiskit.qiskit_utils`.
 
 The noiseless simulation executor can be modified to still perform exact wavefunction
 simulation, but to also include finite sampling of measurements. Note that this executor
@@ -317,17 +317,17 @@ in this example can be found `here <https://quantumcomputing.stackexchange.com/a
 
 Qiskit: Density-matrix Simulation with Noise
 -----------------------------------------------------------
-See :py:func:`mitiq.mitiq_qiskit.qiskit_utils.execute_with_noise`.
+See :py:func:`~mitiq.mitiq_qiskit.qiskit_utils.execute_with_noise` in :py:mod:`~mitiq.mitiq_qiskit.qiskit_utils`.
 
 This executor can be used to simulate a circuit with noise and to return the exact expectation
 value of an observable (without the shot noise typical of a real experiment).
 
-See :py:func:`mitiq.mitiq_qiskit.qiskit_utils.initialized_depolarizing_noise` for an example depolarizing noise
+See :py:func:`~mitiq.mitiq_qiskit.qiskit_utils.initialized_depolarizing_noise` for an example depolarizing noise
 model you can use.
 
 Qiskit: Density-matrix Simulation with Noise and Sampling
 ------------------------------------------------------------------------
-See :py:func:`mitiq.mitiq_qiskit.qiskit_utils.execute_with_shots_and_noise`.
+See :py:func:`~mitiq.mitiq_qiskit.qiskit_utils.execute_with_shots_and_noise` in :py:mod:`~mitiq.mitiq_qiskit.qiskit_utils`.
 
 This executor can be used to simulate a circuit with noise. The expectation value is estimated
 with a finite number of measurements and so it is affected by statistical noise.

--- a/mitiq/mitiq_qiskit/tests/test_zne_mitiq_qiskit.py
+++ b/mitiq/mitiq_qiskit/tests/test_zne_mitiq_qiskit.py
@@ -71,26 +71,23 @@ def measure(circuit, qid) -> QuantumCircuit:
     circuit.measure(0, qid)
     return circuit
 
-
-# TODO: Troubleshoot the problems in this executor.
-#       Causes test time increase to 40+ mins
-# def qiskit_executor(qp: QPROGRAM, shots: int = 500) -> float:
-#     # initialize a qiskit noise model
-#     noise_model = NoiseModel()
-
-#     # we assume a depolarizing error for each gate of the standard IBM basis
-#     # set (u1, u2, u3)
-#     noise_model.add_all_qubit_quantum_error(
-#         depolarizing_error(BASE_NOISE, 1), ["u1", "u2", "u3"]
-#     )
-#     expectation = execute_with_shots_and_noise(
-#         qp,
-#         shots=shots,
-#         obs=ONE_QUBIT_GS_PROJECTOR,
-#         noise_model=noise_model,
-#         seed=1,
-#     )
-#     return expectation
+@pytest.mark.skip(reason="skipping as it can take very long. See PR gh-594.")
+def qiskit_executor(qp: QPROGRAM, shots: int = 500) -> float:
+    # initialize a qiskit noise model
+    noise_model = NoiseModel()
+    # we assume a depolarizing error for each gate of the standard IBM basis
+    # set (u1, u2, u3)
+    noise_model.add_all_qubit_quantum_error(
+        depolarizing_error(BASE_NOISE, 1), ["u1", "u2", "u3"]
+    )
+    expectation = execute_with_shots_and_noise(
+        qp,
+        shots=shots,
+        obs=ONE_QUBIT_GS_PROJECTOR,
+        noise_model=noise_model,
+        seed=1,
+    )
+    return expectation
 
 
 # TODO: Delete and replace with above.


### PR DESCRIPTION
Description
-----------
Add two commits to edit the PR [#584](https://github.com/unitaryfund/mitiq/pull/584/), adding a tilde `~` to make the links look shorter in the userguide when using intersphinx to link the API functions.

Also uncomment a TODO test function that seems to raise a long time issue in testing, by using pytest's `skip`.


Checklist
-----------

Check off the following once complete (or if not applicable). The PR will be reviewed once this
checklist is complete and all tests are passing.

- [ ] I added unit tests for new code.
- [ ] I used [type hints](https://www.python.org/dev/peps/pep-0484/) in function signatures.
- [ ] I used [Google-style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) docstrings for functions.
- [ ] I [updated the documentation](../blob/master/docs/CONTRIBUTING_DOCS.md) where relevant.
- [ ] I updated the [changelog](https://github.com/unitaryfund/mitiq/blob/master/CHANGELOG.md) including author and PR number (@username, gh-xxx)

If some items remain, you can mark this a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).

Tips
----

- If the validation check fails:
  1. Run `make check-style` (from the root directory
  of the repository) and fix any [flake8](http://flake8.pycqa.org) errors.
  2. Run `make format` to format your code with the [black](https://black.readthedocs.io/en/stable/index.html)
  autoformatter.
- Write "Fixes #XYZ" in the description if this PR fixes Issue #XYZ.